### PR TITLE
feat: add undo/redo support

### DIFF
--- a/extension/plugin.lua
+++ b/extension/plugin.lua
@@ -330,6 +330,12 @@ local function onMessage(data)
     end
   elseif msg.type == "draw" then
     handleDrawCommand(msg)
+  elseif msg.type == "undo" then
+    app.command.Undo()
+    sendSpriteData(app.sprite)
+  elseif msg.type == "redo" then
+    app.command.Redo()
+    sendSpriteData(app.sprite)
   end
 end
 

--- a/server/src-tauri/src/lib.rs
+++ b/server/src-tauri/src/lib.rs
@@ -180,7 +180,7 @@ async fn handle_connection(stream: TcpStream, addr: SocketAddr, state: SharedSta
                     }
 
                     // --- Client → Extension ---
-                    "request-sprite-list" | "request-sprite-data" | "draw" => {
+                    "request-sprite-list" | "request-sprite-data" | "draw" | "undo" | "redo" => {
                         let s = state.read().await;
                         // Verify sender is a client.
                         let is_client = s


### PR DESCRIPTION
## Summary
- Handle `"undo"` and `"redo"` message types in the Aseprite extension (`plugin.lua`), calling `app.command.Undo()`/`app.command.Redo()` and sending fresh sprite data back
- Route `"undo"` and `"redo"` messages from clients to the extension in the server relay (`lib.rs`)

Closes #2

## Test plan
- [ ] Connect client and extension via server
- [ ] Perform drawing operations, then send `undo` message from client — verify the last operation is undone and updated sprite data is received
- [ ] Send `redo` message — verify the operation is restored
- [ ] Verify existing draw/sprite-list/sprite-data flows still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)