### PR TITLE
feat: add variable brush size support

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -136,9 +136,9 @@ function applySpriteData(
     setZoomLevel(fitScale * 100);
 
     const drawCallbacks: DrawCallbacks = {
-      onDraw: (x, y, color, tool) => {
+      onDraw: (x, y, color, tool, brushSize) => {
         markDrawActivity();
-        sendMessage({ type: "draw", x, y, color, tool });
+        sendMessage({ type: "draw", x, y, color, tool, brushSize });
       },
       onColorPicked: (color) => {
         drawingState.foregroundColor = color;

--- a/client/src/canvas/drawing.ts
+++ b/client/src/canvas/drawing.ts
@@ -23,6 +23,7 @@ export interface DrawCallbacks {
     y: number,
     color: [number, number, number, number],
     tool: string,
+    brushSize: number,
   ) => void;
   onColorPicked: (color: [number, number, number, number]) => void;
   onTextureUpdate: () => void;
@@ -117,20 +118,42 @@ function colorsEqual(
 
 // ── Drawing primitives ─────────────────────────────────────────────────
 
-function drawPixel(
+/**
+ * Draws a filled square brush of `state.brushSize` pixels centered on (cx, cy).
+ * For brushSize 1 this draws a single pixel.
+ * For brushSize 2+ every pixel in the square is written to the buffer, but
+ * `callbacks.onDraw` is only called once with the center coordinate.
+ */
+function drawBrush(
   state: DrawingState,
   textureSource: BufferImageSource,
-  x: number,
-  y: number,
+  cx: number,
+  cy: number,
   color: [number, number, number, number],
   callbacks: DrawCallbacks,
   skipTextureUpdate: boolean,
 ): void {
   if (!state.pixelBuffer) return;
-  if (x < 0 || y < 0 || x >= state.spriteWidth || y >= state.spriteHeight)
-    return;
 
-  setPixelInBuffer(state.pixelBuffer, x, y, state.spriteWidth, color);
+  const size = state.brushSize;
+  const w = state.spriteWidth;
+  const h = state.spriteHeight;
+  const half = Math.floor(size / 2);
+
+  // Write all pixels in the brush square to the buffer
+  let anyDrawn = false;
+  for (let dy = -half; dy < size - half; dy++) {
+    for (let dx = -half; dx < size - half; dx++) {
+      const px = cx + dx;
+      const py = cy + dy;
+      if (px >= 0 && py >= 0 && px < w && py < h) {
+        setPixelInBuffer(state.pixelBuffer, px, py, w, color);
+        anyDrawn = true;
+      }
+    }
+  }
+
+  if (!anyDrawn) return;
 
   // Sync the texture source resource to our buffer
   textureSource.resource = state.pixelBuffer;
@@ -140,12 +163,13 @@ function drawPixel(
     callbacks.onTextureUpdate();
   }
 
-  callbacks.onDraw(x, y, color, state.tool);
+  // Single callback for the whole brush stamp
+  callbacks.onDraw(cx, cy, color, state.tool, size);
 }
 
 /**
  * Bresenham's line algorithm — ensures no gaps even with fast pen movement.
- * Returns the list of pixel coordinates drawn.
+ * Uses drawBrush at each step to support variable brush sizes.
  */
 function drawLine(
   state: DrawingState,
@@ -165,7 +189,7 @@ function drawLine(
 
   for (;;) {
     // Draw but skip per-pixel texture update — we batch at the end
-    drawPixel(state, textureSource, x0, y0, color, callbacks, true);
+    drawBrush(state, textureSource, x0, y0, color, callbacks, true);
 
     if (x0 === x1 && y0 === y1) break;
 
@@ -221,7 +245,7 @@ function floodFill(
     if (!colorsEqual(current, targetColor)) continue;
 
     setPixelInBuffer(state.pixelBuffer!, x, y, w, fillColor);
-    callbacks.onDraw(x, y, fillColor, "fill");
+    callbacks.onDraw(x, y, fillColor, "fill", 1);
 
     stack.push({ x: x + 1, y });
     stack.push({ x: x - 1, y });
@@ -261,7 +285,7 @@ function applyToolAtPixel(
 ): void {
   switch (state.tool) {
     case "pencil":
-      drawPixel(
+      drawBrush(
         state,
         textureSource,
         x,
@@ -272,7 +296,7 @@ function applyToolAtPixel(
       );
       break;
     case "eraser":
-      drawPixel(state, textureSource, x, y, [0, 0, 0, 0], callbacks, false);
+      drawBrush(state, textureSource, x, y, [0, 0, 0, 0], callbacks, false);
       break;
     case "eyedropper":
       pickColor(state, x, y, callbacks);

--- a/extension/plugin.lua
+++ b/extension/plugin.lua
@@ -220,6 +220,7 @@ local function handleDrawCommand(data)
   local x = data.x
   local y = data.y
   local color = data.color
+  local brushSize = data.brushSize or 1
 
   if not x or not y then
     print("[pxlpad] draw: missing x or y")
@@ -241,9 +242,20 @@ local function handleDrawCommand(data)
     return
   end
 
-  if x < 0 or x >= sprite.width or y < 0 or y >= sprite.height then
-    return
+  -- Collect all pixels to draw (brush square centered on x,y)
+  local pixels = {}
+  local half = math.floor(brushSize / 2)
+  for dy = -half, brushSize - half - 1 do
+    for dx = -half, brushSize - half - 1 do
+      local px = x + dx
+      local py = y + dy
+      if px >= 0 and px < sprite.width and py >= 0 and py < sprite.height then
+        pixels[#pixels + 1] = { x = px, y = py }
+      end
+    end
   end
+
+  if #pixels == 0 then return end
 
   local cel = app.cel
   suppressChange = true
@@ -252,35 +264,63 @@ local function handleDrawCommand(data)
     if cel then
       local img = cel.image:clone()
       local celPos = cel.position
-      local localX = x - celPos.x
-      local localY = y - celPos.y
 
-      -- If pixel is within current cel bounds, draw directly
-      if localX >= 0 and localX < img.width and localY >= 0 and localY < img.height then
-        img:drawPixel(localX, localY, app.pixelColor.rgba(r, g, b, a))
-        cel.image = img
-      else
-        -- Expand cel to include the new pixel
-        local newX = math.min(celPos.x, x)
-        local newY = math.min(celPos.y, y)
-        local newW = math.max(celPos.x + img.width, x + 1) - newX
-        local newH = math.max(celPos.y + img.height, y + 1) - newY
+      -- Calculate bounding box including all brush pixels
+      local minX = celPos.x
+      local minY = celPos.y
+      local maxX = celPos.x + img.width - 1
+      local maxY = celPos.y + img.height - 1
 
+      for _, p in ipairs(pixels) do
+        if p.x < minX then minX = p.x end
+        if p.y < minY then minY = p.y end
+        if p.x > maxX then maxX = p.x end
+        if p.y > maxY then maxY = p.y end
+      end
+
+      -- Check if we need to expand the cel
+      if minX < celPos.x or minY < celPos.y or maxX >= celPos.x + img.width or maxY >= celPos.y + img.height then
+        local newW = maxX - minX + 1
+        local newH = maxY - minY + 1
         local newImg = Image(newW, newH, sprite.colorMode)
         newImg:clear()
-        newImg:drawImage(img, celPos.x - newX, celPos.y - newY)
-        newImg:drawPixel(x - newX, y - newY, app.pixelColor.rgba(r, g, b, a))
+        newImg:drawImage(img, celPos.x - minX, celPos.y - minY)
+
+        for _, p in ipairs(pixels) do
+          newImg:drawPixel(p.x - minX, p.y - minY, app.pixelColor.rgba(r, g, b, a))
+        end
+
         cel.image = newImg
-        cel.position = Point(newX, newY)
+        cel.position = Point(minX, minY)
+      else
+        for _, p in ipairs(pixels) do
+          img:drawPixel(p.x - celPos.x, p.y - celPos.y, app.pixelColor.rgba(r, g, b, a))
+        end
+        cel.image = img
       end
     else
-      -- No cel exists — create one with a single pixel
+      -- No cel exists — create one covering the brush area
       local layer = app.layer
       if not layer then return end
       local frameNum = app.frame and app.frame.frameNumber or 1
-      local newImg = Image(1, 1, sprite.colorMode)
-      newImg:drawPixel(0, 0, app.pixelColor.rgba(r, g, b, a))
-      sprite:newCel(layer, frameNum, newImg, Point(x, y))
+
+      local minX = pixels[1].x
+      local minY = pixels[1].y
+      local maxX = pixels[1].x
+      local maxY = pixels[1].y
+      for i = 2, #pixels do
+        if pixels[i].x < minX then minX = pixels[i].x end
+        if pixels[i].y < minY then minY = pixels[i].y end
+        if pixels[i].x > maxX then maxX = pixels[i].x end
+        if pixels[i].y > maxY then maxY = pixels[i].y end
+      end
+
+      local newImg = Image(maxX - minX + 1, maxY - minY + 1, sprite.colorMode)
+      newImg:clear()
+      for _, p in ipairs(pixels) do
+        newImg:drawPixel(p.x - minX, p.y - minY, app.pixelColor.rgba(r, g, b, a))
+      end
+      sprite:newCel(layer, frameNum, newImg, Point(minX, minY))
     end
   end)
 


### PR DESCRIPTION
## Summary
- Add `drawBrush` function in the drawing engine that draws a filled square of `brushSize x brushSize` pixels centered on the target coordinate, replacing single-pixel `drawPixel` for pencil and eraser tools
- Include `brushSize` in the WebSocket `draw` message so the Aseprite extension applies the same brush
- Update the extension's `handleDrawCommand` to draw a filled square and properly expand the cel bounding box for multi-pixel brushes

Closes #3

## Test plan
- [ ] Set brush size to 1 and verify pencil/eraser draw single pixels (no regression)
- [ ] Set brush size to 3+ and verify pencil draws a filled square centered on the cursor
- [ ] Set brush size to 3+ and verify eraser clears a filled square
- [ ] Draw a line by dragging with brush size > 1 and verify no gaps appear
- [ ] Verify drawn pixels sync correctly to Aseprite via the extension
- [ ] Verify flood fill still works normally (always uses size 1)
- [ ] Verify eyedropper still picks from the exact cursor pixel

🤖 Generated with [Claude Code](https://claude.com/claude-code)