### PR TITLE
feat: sync Aseprite palette to client

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -22,6 +22,7 @@ import {
 import type { DrawCallbacks } from "./canvas/drawing.ts";
 
 import { useDrawingState } from "./composables/useDrawingState.ts";
+import type { RGBA } from "./composables/useDrawingState.ts";
 import { useEditorState } from "./composables/useEditorState.ts";
 import { useWebSocket } from "./composables/useWebSocket.ts";
 
@@ -31,6 +32,7 @@ const {
   state: drawingReactive,
   setForegroundColor,
   addRecentColor,
+  setPalette,
 } = useDrawingState();
 const { setSpriteName, setCursorPosition, setZoomLevel, setStatus } =
   useEditorState();
@@ -260,6 +262,13 @@ onMounted(async () => {
       case "sprite-update": {
         console.log("[WS] Sprite update notification");
         sendMessage({ type: "request-sprite-data" });
+        break;
+      }
+
+      case "palette-data": {
+        const colors = msg.colors as number[][];
+        console.log(`[WS] Palette received (${colors.length} colors)`);
+        setPalette(colors.map((c) => [c[0], c[1], c[2], c[3]] as RGBA));
         break;
       }
 

--- a/client/src/components/ColorPalette.vue
+++ b/client/src/components/ColorPalette.vue
@@ -20,6 +20,12 @@ function recentColorAt(index: number): RGBA {
     ? state.recentColors[index]
     : emptyColor;
 }
+
+function selectPaletteColor(index: number) {
+  if (index < state.palette.length) {
+    setForegroundColor([...state.palette[index]] as RGBA);
+  }
+}
 </script>
 
 <template>
@@ -31,7 +37,21 @@ function recentColorAt(index: number): RGBA {
       <ArrowRightLeft :size="14" :stroke-width="2" />
     </PxlButton>
 
-    <span class="recent-label">Recent</span>
+    <template v-if="state.palette.length > 0">
+      <span class="section-label">Palette</span>
+
+      <div class="pxl-palette-colors">
+        <ColorSwatch
+          v-for="(color, i) in state.palette"
+          :key="'pal-' + i"
+          :color="color"
+          variant="recent"
+          @click="selectPaletteColor(i)"
+        />
+      </div>
+    </template>
+
+    <span class="section-label">Recent</span>
 
     <div class="pxl-recent-colors">
       <ColorSwatch
@@ -80,12 +100,13 @@ function recentColorAt(index: number): RGBA {
   margin-top: -6px;
 }
 
-.recent-label {
+.section-label {
   font-size: 10px;
   color: var(--ui-text-muted);
   margin-top: 4px;
 }
 
+.pxl-palette-colors,
 .pxl-recent-colors {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/client/src/composables/useDrawingState.ts
+++ b/client/src/composables/useDrawingState.ts
@@ -9,6 +9,7 @@ interface DrawingState {
   backgroundColor: RGBA;
   brushSize: number;
   recentColors: RGBA[];
+  palette: RGBA[];
 }
 
 const state = reactive<DrawingState>({
@@ -17,6 +18,7 @@ const state = reactive<DrawingState>({
   backgroundColor: [255, 255, 255, 255],
   brushSize: 1,
   recentColors: [],
+  palette: [],
 });
 
 export function useDrawingState() {
@@ -42,6 +44,10 @@ export function useDrawingState() {
     state.backgroundColor = tmp;
   }
 
+  function setPalette(colors: RGBA[]) {
+    state.palette = colors;
+  }
+
   function addRecentColor(color: RGBA) {
     const idx = state.recentColors.findIndex(
       (c) =>
@@ -63,5 +69,6 @@ export function useDrawingState() {
     setBrushSize,
     swapColors,
     addRecentColor,
+    setPalette,
   };
 }

--- a/client/src/composables/useWebSocket.ts
+++ b/client/src/composables/useWebSocket.ts
@@ -39,6 +39,7 @@ export function useWebSocket() {
 
         sendMessage({ type: "register", role: "client" });
         sendMessage({ type: "request-sprite-list" });
+        sendMessage({ type: "request-palette" });
       });
 
       ws.addEventListener("message", (event: MessageEvent) => {

--- a/extension/plugin.lua
+++ b/extension/plugin.lua
@@ -190,6 +190,24 @@ local function attachSpriteListener(sprite)
   end)
 end
 
+local function sendPaletteData(sprite)
+  if not connected or not ws or not sprite then return end
+
+  local palette = sprite.palettes[1]
+  if not palette then return end
+
+  local colors = {}
+  for i = 0, #palette - 1 do
+    local c = palette:getColor(i)
+    colors[#colors + 1] = { c.red, c.green, c.blue, c.alpha }
+  end
+
+  ws:sendText(jsonEncode({
+    type = "palette-data",
+    colors = colors,
+  }))
+end
+
 local function sendSpriteList()
   if not connected or not ws then return end
 
@@ -304,9 +322,10 @@ local function onConnected()
   -- Send sprite list
   sendSpriteList()
 
-  -- Send initial sprite data if there is an active sprite
+  -- Send initial sprite data and palette if there is an active sprite
   if app.sprite then
     sendSpriteData(app.sprite)
+    sendPaletteData(app.sprite)
     attachSpriteListener(app.sprite)
   end
 end
@@ -327,6 +346,10 @@ local function onMessage(data)
   elseif msg.type == "request-sprite-data" then
     if app.sprite then
       sendSpriteData(app.sprite)
+    end
+  elseif msg.type == "request-palette" then
+    if app.sprite then
+      sendPaletteData(app.sprite)
     end
   elseif msg.type == "draw" then
     handleDrawCommand(msg)

--- a/server/src-tauri/src/lib.rs
+++ b/server/src-tauri/src/lib.rs
@@ -160,7 +160,7 @@ async fn handle_connection(stream: TcpStream, addr: SocketAddr, state: SharedSta
                     }
 
                     // --- Extension → Clients ---
-                    "sprite-list" | "sprite-data" | "sprite-update" => {
+                    "sprite-list" | "sprite-data" | "sprite-update" | "palette-data" => {
                         let s = state.read().await;
                         // Verify sender is an extension.
                         let is_extension = s
@@ -180,7 +180,7 @@ async fn handle_connection(stream: TcpStream, addr: SocketAddr, state: SharedSta
                     }
 
                     // --- Client → Extension ---
-                    "request-sprite-list" | "request-sprite-data" | "draw" => {
+                    "request-sprite-list" | "request-sprite-data" | "request-palette" | "draw" => {
                         let s = state.read().await;
                         // Verify sender is a client.
                         let is_client = s


### PR DESCRIPTION
## Summary
- Add `sendPaletteData()` function to Aseprite extension that reads `sprite.palettes[1]` and sends color data as `palette-data` messages
- Route `palette-data` (extension to clients) and `request-palette` (client to extension) through the relay server
- Add `palette` state and `setPalette()` to `useDrawingState` composable
- Display synced palette colors in `ColorPalette.vue` grid; clicking a swatch sets it as the foreground color
- Request palette on WebSocket connect alongside sprite list

Closes #5

## Test plan
- [ ] Connect Aseprite with the extension to the relay server
- [ ] Open a sprite with a custom palette in Aseprite
- [ ] Verify the palette colors appear in the client's color panel under "Palette"
- [ ] Click a palette swatch and verify it sets the foreground color
- [ ] Reconnect and verify the palette is re-fetched automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)